### PR TITLE
Add files required to use MWLib as a cocoapod

### DIFF
--- a/Specs/J2ObjC/0.9.7/J2ObjC.podspec.json
+++ b/Specs/J2ObjC/0.9.7/J2ObjC.podspec.json
@@ -1,0 +1,77 @@
+{
+  "name": "J2ObjC",
+  "version": "0.9.7",
+  "license": {
+    "type": "Apache License, Version 2.0",
+    "file": "LICENSE"
+  },
+  "summary": "J2ObjC's JRE emulation library, emulates a subset of the Java runtime library.",
+  "homepage": "https://github.com/google/j2objc",
+  "authors": "Google Inc.",
+  "source": {
+    "git": "https://github.com/goodow/j2objc.git",
+    "commit": "9c8037ce8d97fc88ca477afe5313923bae827096"
+  },
+  "platforms": {
+    "ios": "5.0",
+    "osx": "10.7"
+  },
+  "requires_arc": false,
+  "default_subspecs": "lib/jre",
+  "prepare_command": "    scripts/download_distribution.sh\n",
+  "subspecs": [
+    {
+      "name": "lib",
+      "frameworks": "Security",
+      "osx": {
+        "frameworks": "ExceptionHandling"
+      },
+      "xcconfig": {
+        "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/J2ObjC/dist/lib\"",
+        "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/J2ObjC/dist/include\""
+      },
+      "subspecs": [
+        {
+          "name": "jre",
+          "preserve_paths": "dist",
+          "libraries": [
+            "jre_emul",
+            "icucore",
+            "z"
+          ]
+        },
+        {
+          "name": "jsr305",
+          "dependencies": {
+            "J2ObjC/lib/jre": [
+
+            ]
+          },
+          "libraries": "jsr305"
+        },
+        {
+          "name": "junit",
+          "dependencies": {
+            "J2ObjC/lib/jre": [
+
+            ]
+          },
+          "libraries": [
+            "j2objc_main",
+            "junit",
+            "mockito"
+          ]
+        },
+        {
+          "name": "guava",
+          "dependencies": {
+            "J2ObjC/lib/jre": [
+
+            ]
+          },
+          "libraries": "guava"
+        }
+      ]
+    }
+  ]
+}

--- a/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
+++ b/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
@@ -16,13 +16,6 @@
   },
   "source_files": "ios_release/**/*.{h,m}",
   "header_mappings_dir": "ios_release",
-  "libraries": [
-    "z",
-    "icucore"
-  ],
-  "frameworks": [
-    "Security"
-  ],
   "dependencies": {
     "J2ObjC": "~> 0.9.7"
   },

--- a/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
+++ b/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
@@ -1,0 +1,32 @@
+{
+  "name": "MiddlewareLib",
+  "version": "0.8.0",
+  "summary": "Library that is the middleware between NPC´s Apps and NPC´s services",
+  "homepage": "https://github.com/indigotech/br-npc-middleware-lib-java/",
+  "license": {
+    "type": "Comercial"
+  },
+  "authors": {"Taqtile": "contato@taqtile.com"},
+  "source": {
+    "git": "https://github.com/indigotech/br-npc-middleware-lib-java/",
+    "tag": "0.8.0"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": "ios_release/**/*.{h,m}",
+  "header_mappings_dir": "ios_release",
+  "libraries": [
+    "z",
+    "icucore"
+  ],
+  "frameworks": [
+    "Security"
+  ],
+  "dependencies": {
+    "J2ObjC": "~> 0.9.7"
+  },
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/J2ObjC/dist/include\""
+  }
+}

--- a/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
+++ b/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
@@ -4,7 +4,7 @@
   "summary": "Library that is the middleware between NPC´s Apps and NPC´s services",
   "homepage": "https://github.com/indigotech/br-npc-middleware-lib-java/",
   "license": {
-    "type": "Comercial"
+    "type": "Commercial"
   },
   "authors": {"Taqtile": "contato@taqtile.com"},
   "source": {


### PR DESCRIPTION
Both MiddlewareLib.podspec.json and J2ObjC.podspec.json are being added.
J2ObjC is added because the repository in which it is hosted don´t have
the tag v0.9.7-lib yet, so we use master branch.
Check https://github.com/goodow/j2objc.git.