### PR TITLE
Update middleware lib specs to 0.8.0-alpha.1 version

### DIFF
--- a/Specs/MiddlewareLib/0.8.0-alpha.1/MiddlewareLib.podspec.json
+++ b/Specs/MiddlewareLib/0.8.0-alpha.1/MiddlewareLib.podspec.json
@@ -8,7 +8,7 @@
   },
   "authors": {"Taqtile": "contato@taqtile.com"},
   "source": {
-    "git": "git@github.com:indigotech/br-npc-middleware-lib-java.git",
+    "git": "https://github.com/indigotech/br-npc-middleware-lib-java/",
     "tag": "0.8.0-alpha.1"
   },
   "platforms": {

--- a/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
+++ b/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
@@ -8,7 +8,7 @@
   },
   "authors": {"Taqtile": "contato@taqtile.com"},
   "source": {
-    "git": "https://github.com/indigotech/br-npc-middleware-lib-java/",
+    "git": "git@github.com:indigotech/br-npc-middleware-lib-java.git",
     "tag": "0.8.0"
   },
   "platforms": {

--- a/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
+++ b/Specs/MiddlewareLib/0.8.0/MiddlewareLib.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MiddlewareLib",
-  "version": "0.8.0",
+  "version": "0.8.0-alpha.1",
   "summary": "Library that is the middleware between NPC´s Apps and NPC´s services",
   "homepage": "https://github.com/indigotech/br-npc-middleware-lib-java/",
   "license": {
@@ -9,7 +9,7 @@
   "authors": {"Taqtile": "contato@taqtile.com"},
   "source": {
     "git": "git@github.com:indigotech/br-npc-middleware-lib-java.git",
-    "tag": "0.8.0"
+    "tag": "0.8.0-alpha.1"
   },
   "platforms": {
     "ios": "5.0"


### PR DESCRIPTION
Since ios_release folder is necessary and its only present from 0.8.0-alpha.1 onward we needed to update the specs in order to dependant projects to work.